### PR TITLE
fix event handling to support cache deletion again

### DIFF
--- a/cmd/cache-service/cache-service.go
+++ b/cmd/cache-service/cache-service.go
@@ -19,7 +19,7 @@ func main() {
 	arango.InitializeArangoDbAdapter(logrus.StandardLogger(), config)
 
 	redis.InitializeRedisClient()
-	messages.StartEventConsumption()
+	messages.StartEventConsumption(messages.GetCacheServiceMessageHandlers())
 	redis.InitializeCache()
 	messages.StartEventProcessing()
 }

--- a/cmd/subscription-service/subscription-service.go
+++ b/cmd/subscription-service/subscription-service.go
@@ -24,7 +24,7 @@ func main() {
 	arango.InitializeArangoDbAdapter(logrus.StandardLogger(), config)
 
 	messages.InitializeTopics()
-	messages.StartEventConsumption()
+	messages.StartEventConsumption(messages.GetSubscriptionServiceMessageHandlers())
 
 	serverAddress := os.Getenv("APP_SERVER_ADDRESS")
 

--- a/pkg/messages/helpers.go
+++ b/pkg/messages/helpers.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 
 	"github.com/Shopify/sarama"
+	"github.com/jalapeno-api-gateway/jagw/pkg/model/class"
 	"github.com/sirupsen/logrus"
 )
 
@@ -14,4 +15,44 @@ func unmarshalKafkaMessage(msg *sarama.ConsumerMessage) KafkaEventMessage {
 		logrus.WithError(err).Panic("Failed to unmarshal Kafka message.")
 	}
 	return event
+}
+
+func GetCacheServiceMessageHandlers() map[string]MessageHandler {
+	return map[string]MessageHandler{
+		LSNODE_KAFKA_TOPIC: func(msg KafkaEventMessage) {
+			LsNodeEvents <- msg
+		},
+		LSLINK_KAFKA_TOPIC: func(msg KafkaEventMessage) {
+			LsLinkEvents <- msg
+		},
+		LSPREFIX_KAFKA_TOPIC: func(msg KafkaEventMessage) {
+			LsPrefixEvents <- msg
+		},
+		LSSRV6SID_KAFKA_TOPIC: func(msg KafkaEventMessage) {
+			LsSrv6SidEvents <- msg
+		},
+		LSNODE_EDGE_KAFKA_TOPIC: func(msg KafkaEventMessage) {
+			LsNodeEdgeEvents <- msg
+		},
+	}
+}
+
+func GetSubscriptionServiceMessageHandlers() map[string]MessageHandler {
+	return map[string]MessageHandler{
+		LSNODE_KAFKA_TOPIC: func(msg KafkaEventMessage) {
+			handleTopologyEvent(msg, class.LsNode)
+		},
+		LSLINK_KAFKA_TOPIC: func(msg KafkaEventMessage) {
+			handleTopologyEvent(msg, class.LsLink)
+		},
+		LSPREFIX_KAFKA_TOPIC: func(msg KafkaEventMessage) {
+			handleTopologyEvent(msg, class.LsPrefix)
+		},
+		LSSRV6SID_KAFKA_TOPIC: func(msg KafkaEventMessage) {
+			handleTopologyEvent(msg, class.LsSrv6Sid)
+		},
+		LSNODE_EDGE_KAFKA_TOPIC: func(msg KafkaEventMessage) {
+			handleTopologyEvent(msg, class.LsNodeEdge)
+		},
+	}
 }


### PR DESCRIPTION
During the merge into the mono repo, the two files were merged into one:
- https://github.com/jalapeno-api-gateway/cache-service/blob/dev/kafka/eventlisteners.go
- https://github.com/jalapeno-api-gateway/subscription-service/blob/dev/kafka/eventlisteners.go


However, the logic was not merged identically, leading to the cache service crash mentioned in #3.

The problem was that the cache service called the wrong functions (which were supposed to be called by the subscription service; thus, the dependencies weren't initialized, which caused the panic).


This commit merged the original logic and thus fixed the panic of the cash service.

Please look at the code and merge it if it's okay.
After the merge, a new release should be made so the new version can be deployed again.

